### PR TITLE
Modifiable shop currency + fixed decimals not charging

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,10 +34,13 @@ or copy it to the templates dir in your project.
 
 
     SHOP_HANDLER_PAYMENT = 'cartridge_stripe.payment_handler'
-    SHOP_CHECKOUT_FORM_CLASS = 'cartridge_stripe.forms.OrderForm'
 
     ZEBRA_ENABLE_APP = True
 
+Update the urls.py. Add the following line above the r'^shop/'.
+::
+    url(r'^shop/checkout/$', 'cartridge.shop.views.checkout_steps', name='checkout_steps',
+       kwargs=dict(form_class=OrderForm)),
 
 =======
 Style

--- a/README.rst
+++ b/README.rst
@@ -43,6 +43,13 @@ Update the urls.py. Add the following line above the r'^shop/'.
        kwargs=dict(form_class=OrderForm)),
 
 =======
+Optional
+=======
+cartridg-stripe will by default accept payments in USD. If you need to you can change the currency stripe should accept payment in. Update settings.py with the following line. Replace 'cad' with your currency of choice.
+::
+    SHOP_CHARGE_CURRENCY = 'cad'
+
+=======
 Style
 =======
 

--- a/cartridge_stripe/__init__.py
+++ b/cartridge_stripe/__init__.py
@@ -31,7 +31,7 @@ def payment_handler(request, order_form, order):
     tok = order_form.cleaned_data['stripe_token']
     total = order.total
     try:
-        charge = stripe.Charge.create(amount=int(total) * 100,
+        charge = stripe.Charge.create(amount=int(total *100),
                                       currency=CURRENCY,
                                       card=tok,
                                       description=order)

--- a/cartridge_stripe/__init__.py
+++ b/cartridge_stripe/__init__.py
@@ -3,8 +3,11 @@ import cartridge
 import stripe
 
 from django.utils.translation import ugettext as _
+from django.conf import settings
 
 logger = logging.getLogger(__name__)
+
+CURRENCY = getattr(settings, 'SHOP_CHARGE_CURRENCY', 'usd')
 
 
 class CheckoutError(Exception):
@@ -29,7 +32,7 @@ def payment_handler(request, order_form, order):
     total = order.total
     try:
         charge = stripe.Charge.create(amount=int(total) * 100,
-                                      currency="usd",
+                                      currency=CURRENCY,
                                       card=tok,
                                       description=order)
         return charge.id


### PR DESCRIPTION
Allow stripe to accept payments in currency other than 'usd'. Defaults to 'usd' so not to break current cartridge-stripe users functionality. Updated readme including fix for deprecated feature warning message. Fixed decimals not charging properly, used to round down to integer.
